### PR TITLE
📝 Docs: Add docstrings to revancedbot and implement centralized error reporting

### DIFF
--- a/revancedbot/__init__.py
+++ b/revancedbot/__init__.py
@@ -8,6 +8,7 @@ from github import Github
 from dataclasses import dataclass
 import subprocess
 from selenium import webdriver
+from .errors import report_error
 from selenium.webdriver.common.by import By
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import WebDriverWait
@@ -17,12 +18,31 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class PatchJob:
+    """
+    Represents a specific application version targeted for patching.
+
+    This acts as the fundamental unit of work across the pipeline (discovery -> fetch -> patch).
+    By holding `package_id` and an optional `package_version`, it allows targeting
+    either a specific known-good release or dynamically fetching the 'latest'.
+    """
     package_id: str
     package_version: Optional[str] # latest if None
 
 
 class ApkpureFetcher():
+    """
+    Handles headless browser automation to scrape and download APKs from APKPure.
+
+    It configures a dedicated Chrome profile to automatically save files into `location`
+    without prompting, sidestepping bot-protections or manual dialogs.
+    """
     def __init__(self, location: Path):
+        """
+        Initializes the Chrome webdriver with automated download settings.
+
+        Args:
+            location (Path): The target directory where `.apk` files will be dropped.
+        """
         location.mkdir(parents=True, exist_ok=True)
         self.location = location
         prefs = {
@@ -38,12 +58,26 @@ class ApkpureFetcher():
         self.driver = webdriver.Chrome(options=options)
 
     def url_from_job(self, job: PatchJob):
+        """Builds the direct APKPure download URL for a given PatchJob."""
         return f"https://d.apkpure.com/b/APK/{job.package_id}?version={job.package_version or 'latest'}"
 
     def fetch(self, job: PatchJob):
+        """
+        Triggers the browser to navigate to the download link.
+
+        This initiates the download asynchronously within the browser session.
+        It does not block until the download is complete; use `wait_settle` for that.
+        """
         self.driver.get(self.url_from_job(job))
 
     def wait_settle(self):
+        """
+        Blocks execution until all active Chrome downloads finish.
+
+        It polls the target directory for Chrome's temporary `.crdownload` files,
+        waiting until none remain. It also enforces a final 5-second sleep to ensure
+        file system handles are released before closing the browser.
+        """
         while True:
             logger.info("Checking if downloads are finished")
             pending = list(self.location.glob("*.crdownload"))
@@ -55,7 +89,18 @@ class ApkpureFetcher():
         self.driver.close()
 
 class Patcher():
+    """
+    Wrapper for the external ReVanced Java tooling (CLI and Patches).
+
+    It is responsible for bootstrapping the required `.jar` and `.rvp` assets from GitHub
+    releases if they are missing, and executing the patching commands in a subprocess.
+    """
     def __init__(self, tool_location: Path =None):
+        """
+        Sets up the working directory for the ReVanced toolchain.
+
+        If no path is provided, it falls back to a temporary directory.
+        """
         if tool_location is None:
             tool_location = Path(tempfile.mkdtemp()).parent / "revancedbot"
         self.tool_location = tool_location
@@ -70,6 +115,12 @@ class Patcher():
         return self.tool_location / "patcher.jar"
 
     def _startup(self):
+        """
+        Lazy-loads the ReVanced CLI and Patches bundles from GitHub.
+
+        This makes an unauthenticated API call to GitHub to find the latest releases.
+        It runs exactly once per instance to avoid unnecessary network latency or rate limits.
+        """
         if self._started is not None:
             return
         g = Github()
@@ -86,6 +137,13 @@ class Patcher():
         self._started = True
 
     def __call__(self, *args, stdin=None, stdout=None, stderr=None):
+        """
+        Executes a command against the ReVanced CLI jar.
+
+        Args:
+            *args: CLI arguments to pass to the jar (e.g., 'patch', '-o', ...).
+            stdin, stdout, stderr: File handles for redirecting I/O streams.
+        """
         self._startup()
         return subprocess.run(
             ["java", "-jar", self.patcher_file, *args],
@@ -96,6 +154,12 @@ class Patcher():
     
     @property
     def jobs(self):
+        """
+        Parses the `.rvp` bundle to discover all patchable apps and their compatible versions.
+
+        Yields:
+            PatchJob: A job definition for each compatible package/version pair found.
+        """
         data = self("list-versions", self.patch_file, stdout=subprocess.PIPE).stdout.decode()
         for package in data.split("Package name: "):
             package_parts = package.split("Most common compatible versions:")
@@ -110,7 +174,22 @@ class Patcher():
                 yield PatchJob(package_id=package_id, package_version=None if version == 'Any' else version)
 
 class App:
+    """
+    High-level orchestrator for the entire fetch-and-patch lifecycle.
+
+    It connects the `Patcher` (for discovering what needs patching and doing the work)
+    with the `ApkpureFetcher` (for acquiring the raw APKs). It maintains internal state
+    to avoid re-fetching or re-discovering jobs unnecessarily.
+    """
     def __init__(self, root=Path("/tmp/revancedbot"), lowlimit=False):
+        """
+        Initializes the application state and its dependencies.
+
+        Args:
+            root (Path): Base directory for tooling, downloaded APKs, and patched outputs.
+            lowlimit (bool): If True, restricts the pipeline to only process the first 3 jobs,
+                             useful for testing or debugging without doing a full run.
+        """
         self.root = root
         self.patcher = Patcher(root/"patcher")
         self.lowlimit = lowlimit
@@ -119,6 +198,10 @@ class App:
 
     @property
     def jobs(self):
+        """
+        Retrieves the list of target patch jobs, lazily querying the Patcher if needed.
+        Applies the `lowlimit` slice if configured.
+        """
         if self._jobs is None:
             self._jobs = list(self.patcher.jobs)
         if self.lowlimit:
@@ -127,6 +210,12 @@ class App:
 
     @property
     def fetched_apks(self):
+        """
+        Downloads the raw APKs for all identified jobs.
+
+        It caches the resulting file paths in memory after the first run.
+        This property has significant side effects (network I/O, file creation, headless browser execution).
+        """
         apk_dir = self.root / "downloaded_apks"
         apk_dir.mkdir(parents=True, exist_ok=True)
         if self._fetched_apks is None:
@@ -141,18 +230,33 @@ class App:
     
     @property
     def patched_apks(self):
+        """
+        Iterates over all downloaded APKs and applies the ReVanced patches to them.
+
+        Yields the processed files into the `patched_apks` directory.
+        Any patching failures are caught, reported, and bypassed to allow the batch to continue.
+        """
         apk_dir = self.root / "patched_apks"
         apk_dir.mkdir(parents=True, exist_ok=True)
         for fetched_apk in self.fetched_apks:
             try:
                 logger.info(f"Patching {fetched_apk.name}...")
                 self.patcher("patch", fetched_apk, "-o", apk_dir / fetched_apk.name, f"-p={self.patcher.patch_file}")
-            except:
-                pass
+            except Exception as e:
+                report_error(e, context=f"Failed to patch {fetched_apk.name}")
 
     
 
 def run_patcher():
+    """
+    CLI entry point for the `repatcher` command.
+
+    Parses a simple subcommand from `sys.argv[1]` to execute parts of the pipeline:
+      - 'jobs': Lists discovered target apps and versions.
+      - 'fetch': Downloads the target APKs.
+      - 'patch-all': Runs the full fetch-and-patch sequence.
+      - (fallback): Passes remaining args directly to the underlying ReVanced CLI.
+    """
     logging.basicConfig(level=logging.DEBUG)
     a = App()
     if sys.argv[1] == 'jobs':

--- a/revancedbot/errors.py
+++ b/revancedbot/errors.py
@@ -1,0 +1,23 @@
+import logging
+import traceback
+
+logger = logging.getLogger(__name__)
+
+def report_error(e: Exception, context: str = "") -> None:
+    """
+    Centralized error-reporting function.
+
+    All unexpected exceptions and empty catch blocks must be routed through this function.
+    It ensures errors are captured with their full traceback and any additional context.
+    If Sentry or another tracking backend is added later, it should be hooked in here.
+
+    Args:
+        e (Exception): The exception that was caught.
+        context (str, optional): Additional context about where or why the error occurred.
+    """
+    error_msg = f"Unexpected error: {str(e)}"
+    if context:
+        error_msg = f"{context} - {error_msg}"
+
+    logger.error(error_msg)
+    logger.error(traceback.format_exc())


### PR DESCRIPTION
**Assumptions:**
- The existing empty `except:` block in `App.patched_apks` was intended to allow batch processing to continue if one apk failed, so `report_error` was used to log it without raising and halting execution.
- Standard python `logging` was appropriate for `report_error` since no Sentry configuration was provided.

**Alternatives Not Chosen:**
- Adding type hints to everything; this was avoided to prevent redundant typing info in comments.
- Documenting trivial properties like `patch_file` and `patcher_file`; skipped to avoid verbose getter/setter descriptions.

**How To Pivot:**
- If the centralized error reporting should use a different backend (e.g., Sentry), modify `revancedbot/errors.py`.
- If the docstrings are too verbose, pare them down in `revancedbot/__init__.py`.

**Next Knobs:**
- `revancedbot/errors.py`: The `report_error` function can be easily hooked up to Sentry or another tracking service.
- `App.patched_apks`: The `except Exception as e:` block can be narrowed down if specific error types are expected.

---
*PR created automatically by Jules for task [6628887878269271590](https://jules.google.com/task/6628887878269271590) started by @lucasew*